### PR TITLE
Added test and updated decorator

### DIFF
--- a/signal_disabler/signal_disabler.py
+++ b/signal_disabler/signal_disabler.py
@@ -21,8 +21,10 @@ class disable(object):
         @functools.wraps(fn)
         def decorated(*args, **kwargs):
             self.disconnect_all()
-            fn(*args, **kwargs)
-            self.reconnect_all()
+            try:
+                fn(*args, **kwargs)
+            finally:
+                self.reconnect_all()
         return decorated
 
     def __enter__(self):

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -29,3 +29,20 @@ def test_fail_as_uninstantiated_decorator(db):
 
     with pytest.raises(AttributeError):
         save()
+
+
+def test_signals_reconnected_after_exception(db):
+    obj = CustomModel()
+
+    @signal_disabler.disable()
+    def fails():
+        raise Exception
+
+    try:
+        fails()
+    except:
+        pass
+
+    with pytest.raises(PostSaveCalled):
+        obj.save()
+


### PR DESCRIPTION
Test verifies that even when decorated function raises an exception, the signals are reconnected again

Surrounded function call inside decorator with a `try..except` block and reconnected signals in the `finally` clause